### PR TITLE
Mudança concatenação de strings.

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -687,18 +687,27 @@ end
 
 ## Concatenação de strings
 
-Evite usar `String#+` quando precisar construir grandes blocos de dados. Em vez disso, use `String#<<`. A concatenação modifica a instância de string no local e é sempre mais rápida que `String#+`, que cria vários novos objetos de string.
+Como usamos por padrão nos arquivos o comentário mágico `#frozen_string_literal: true`, 
+que informa ao Ruby que todas as strings literais no arquivo estão implicitamente congeladas,
+como se tivessem sido chamado `#freeze` em cada uma delas. Logo, se uma string literal for definida em um arquivo
+com este comentário e você chamar um método nessa string que a modifique-a, como `String#<<`, você obterá
+`RuntimeError: can't modify frozen String`.
+
+Assim, quando precisar construir grandes blocos de dados em arquivo com o método mágico `frozen_string_literal`,
+use sempre`String#+`.
 
 ```ruby
-# ruim
-html = ''
-html += '<h1>Page title</h1>'
+#frozen_string_literal: true
+
+# bom
+html = ""
+html += "<h1>Page title</h1>"
 
 paragraphs.each do |paragraph|
   html += "<p>#{paragraph}</p>"
 end
 
-# bom e mais performatico
+# Gera RuntimeError
 html = ''
 html << '<h1>Page title</h1>'
 


### PR DESCRIPTION
**TÓPICO PARA DISCUSSÃO**

Como vamos adotar o comentário mágico `# frozen_string_literal: true` ([Entenda mais sobre](https://stackoverflow.com/questions/37799296/ruby-what-does-the-comment-frozen-string-literal-true-do)), por padrão nos arquivos. Que ajuda em uma melhor gestão de strings. Temos um problema em strings concatenadas com `<<`, que gera um erro, logo, temos que adotar como bom concatenar strings usando `+=`.

*EXEMPLO*

Olhe esse código, ele imprime o id do objeto de cada uma das variáveis que tem a mesma string.

```ruby
    string1 = "Gominho Totozo"
    string2 = "Gominho Totozo"
    string3 = "Gominho Totozo"

    puts string1.object_id
    puts string2.object_id
    puts string3.object_id
```

Veja o resultado com o comentário mágico presente no arquivo:

```
47368877313320
47368877313320
47368877313320
leadster@2485df97b1c2:/app$ 
```
Perceba que não é instanciado um novo objeto na memória, o Ruby reaproveita o mesmo objeto para strings com valores iguais. Deste modo com todos os arquivos contendo o comentário, tende-se a oferecer uma economia no consumo de recursos na execução do projeto, principalmente memória RAM.


Agora veja o resultado sem o comentário mágico, onde é instanciado objetos diferentes para strings com valores iguais:

```
47003567957700
47003567957680
47003567957660
leadster@2485df97b1c2:/app$ 
```
Com o comentário mágico presente, não pode-se concatenar usando `<<`, somente `+=`.